### PR TITLE
Update query model and queue

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     es_host: str = "http://localhost:9200"
+    ai_api_token: str = ""
     # 추가 설정 가능 (예: 초기 서버 목록 등)
 
 settings = Settings()  # 환경 변수 로드하여 설정 객체 생성

--- a/app/models/query.py
+++ b/app/models/query.py
@@ -3,7 +3,8 @@ from typing import List
 
 class SingleQuery(BaseModel):
     server_id: str   # 대상 AI 서버 식별자
-    query: str       # 질의 내용
+    model: str       # 사용할 모델 이름
+    prompt: str      # 질의 내용
 
 class QueryRequest(BaseModel):
     queries: List[SingleQuery]  # 쿼리 목록 (2개 이상일 수 있음)

--- a/app/queues/task.py
+++ b/app/queues/task.py
@@ -1,8 +1,9 @@
 import asyncio
 
 class QueryTask:
-    def __init__(self, query: str):
-        self.query = query
+    def __init__(self, model: str, prompt: str):
+        self.model = model
+        self.prompt = prompt
         # 현재 이벤트 루프에 연결된 Future 생성
         loop = asyncio.get_event_loop()
         self.future = loop.create_future()

--- a/app/services/query_service.py
+++ b/app/services/query_service.py
@@ -13,7 +13,7 @@ class QueryService:
                 # 대상 서버가 없으면 404 오류 처리
                 raise RuntimeError(f"Server {q.server_id} not found")
             # 큐에 작업 등록하고 Future 확보
-            future = server_queue.submit_query(q.query)
+            future = server_queue.submit_query(q.model, q.prompt)
             futures.append(future)
         # 모든 쿼리 Future들이 완료될 때까지 비동기 대기
         results = await asyncio.gather(*futures)


### PR DESCRIPTION
## Summary
- add `ai_api_token` to settings
- carry model and prompt through the queue
- send token when dispatching to AI server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865f7e1e0508321987f8c6832a3a587